### PR TITLE
Fix requierements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-python==3.8.5 
 plotly==4.12.0
 pandas==1.1.3
 numpy==1.19.2


### PR DESCRIPTION
Since the python version can't be managed by pip this requirement is unnecessary.